### PR TITLE
URL Cleanup

### DIFF
--- a/authorization_and_authentication.md
+++ b/authorization_and_authentication.md
@@ -5,7 +5,7 @@ implements [access control](https://www.rabbitmq.com/access-control.html).
 
 Authentication backends should not be confused with authentication mechanisms,
 which are defined in some protocols supported by RabbitMQ.
-For AMQP 0-9-1 authentication mechanisms, see [documentation](http://www.rabbitmq.com/authentication.html).
+For AMQP 0-9-1 authentication mechanisms, see [documentation](https://www.rabbitmq.com/authentication.html).
 
 ## Definitions
 

--- a/internal_events.md
+++ b/internal_events.md
@@ -37,7 +37,7 @@ to be later served over HTTP to the management plugin UI application.
 Both internal event publishers and consumers interact with the notification
 subsystem using a single module, `rabbit_event`. Publishers typically
 use the `rabbit_event:notify/2` function, consumers register
-[gen_event](http://learnyousomeerlang.com/event-handlers) event handlers.
+[gen_event](https://learnyousomeerlang.com/event-handlers) event handlers.
 
 Every event is an instance of the `#event` record.
 An event has a name (e.g. `connection_created` or `queue_deleted`), a timestamp and an

--- a/queues_and_message_store.md
+++ b/queues_and_message_store.md
@@ -1,7 +1,7 @@
 This file attempts to document the overall structure of a queue, and
 how persistence works.
 
-Each queue is a [gen_server2 Erlang process](http://learnyousomeerlang.com/clients-and-servers). The usual pattern of the API and
+Each queue is a [gen_server2 Erlang process](https://learnyousomeerlang.com/clients-and-servers). The usual pattern of the API and
 implementation being in one file is not applied; `rabbit_amqqueue` is
 the API (a module) and `rabbit_amqqueue_process` is the implementation (a `gen_server2`).
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://learnyousomeerlang.com/clients-and-servers with 1 occurrences migrated to:  
  https://learnyousomeerlang.com/clients-and-servers ([https](https://learnyousomeerlang.com/clients-and-servers) result 200).
* http://learnyousomeerlang.com/event-handlers with 1 occurrences migrated to:  
  https://learnyousomeerlang.com/event-handlers ([https](https://learnyousomeerlang.com/event-handlers) result 200).
* http://www.rabbitmq.com/authentication.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/authentication.html ([https](https://www.rabbitmq.com/authentication.html) result 200).